### PR TITLE
chore(ci): avoid double-quote on dry-run variable

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -80,7 +80,10 @@ jobs:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
         run: |
-          cargo publish -p hw_regmap --token "${CRATES_TOKEN}" "${DRY_RUN}"
+          # DRY_RUN expansion cannot be double quoted when variable contains empty string otherwise cargo publish 
+          # would fail. This is safe since DRY_RUN is handled in the env section above.
+          # shellcheck disable=SC2086
+          cargo publish -p hw_regmap --token "${CRATES_TOKEN}" ${DRY_RUN}
 
       - name: Generate hash
         id: published_hash


### PR DESCRIPTION
If the DRY_RUN variable is empty and double-quoted to perform a safe expansion, then 'cargo publish' treat the environment variable as "" and thus fail by handling an unrecognized argument.